### PR TITLE
[Revision 2] Fix bugs, clone callback support

### DIFF
--- a/src/main/java/org/ecwid/dev/copier/CloneData.java
+++ b/src/main/java/org/ecwid/dev/copier/CloneData.java
@@ -1,0 +1,23 @@
+package org.ecwid.dev.copier;
+
+public class CloneData {
+    private final Object object;
+    private final Object copy;
+
+    public static CloneData of(Object object, Object copy) {
+        return new CloneData(object, copy);
+    }
+
+    public Object getObject() {
+        return object;
+    }
+
+    public Object getCopy() {
+        return copy;
+    }
+
+    private CloneData(Object object, Object copy) {
+        this.object = object;
+        this.copy = copy;
+    }
+}

--- a/src/main/java/org/ecwid/dev/copier/CopierEvent.java
+++ b/src/main/java/org/ecwid/dev/copier/CopierEvent.java
@@ -1,0 +1,32 @@
+package org.ecwid.dev.copier;
+
+import org.ecwid.dev.event.Event;
+import org.ecwid.dev.event.EventType;
+
+public class CopierEvent implements Event<Object> {
+    private final Object data;
+    private final CopierEventType type;
+
+    private CopierEvent(CopierEventType type, Object data) {
+        this.data = data;
+        this.type = type;
+    }
+
+    public static Event<Object> cloneCompleted(Object obj, Object copy) {
+        return new CopierEvent(CopierEventType.CLONE_COMPLETED, CloneData.of(obj, copy));
+    }
+
+    @Override
+    public EventType type() {
+        return type;
+    }
+
+    @Override
+    public Object data() {
+        return data;
+    }
+
+    static CopierEvent objectCreated(Object obj, Object clone) {
+        return new CopierEvent(CopierEventType.OBJECT_CREATED, CloneData.of(obj, clone));
+    }
+}

--- a/src/main/java/org/ecwid/dev/copier/CopierEventType.java
+++ b/src/main/java/org/ecwid/dev/copier/CopierEventType.java
@@ -1,0 +1,7 @@
+package org.ecwid.dev.copier;
+
+import org.ecwid.dev.event.EventType;
+
+public enum CopierEventType implements EventType {
+    OBJECT_CREATED, CLONE_COMPLETED;
+}

--- a/src/main/java/org/ecwid/dev/copier/CopierType.java
+++ b/src/main/java/org/ecwid/dev/copier/CopierType.java
@@ -1,0 +1,16 @@
+package org.ecwid.dev.copier;
+
+import java.util.function.Predicate;
+
+enum CopierType {
+    ARRAY(Class::isArray), OBJECT(clz -> true), NO_OP(clz -> clz.isSynthetic() || clz.isEnum() || clz.isAssignableFrom(Class.class));
+    private final Predicate<Class<?>> handlePredicate;
+
+    CopierType(Predicate<Class<?>> handlePredicate) {
+        this.handlePredicate = handlePredicate;
+    }
+
+    boolean canHandle(Object obj) {
+        return handlePredicate.test(obj.getClass());
+    }
+}

--- a/src/main/java/org/ecwid/dev/copier/DeepObjectCopier.java
+++ b/src/main/java/org/ecwid/dev/copier/DeepObjectCopier.java
@@ -1,30 +1,40 @@
 package org.ecwid.dev.copier;
 
 import org.ecwid.dev.copier.fieldcloner.FieldClonerFactory;
+import org.ecwid.dev.event.Event;
+import org.ecwid.dev.event.EventEmitter;
+import org.ecwid.dev.event.EventObserver;
 import org.ecwid.dev.util.MapBuilder;
 
 import java.util.EnumMap;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public final class DeepObjectCopier implements Copier {
+import static org.ecwid.dev.copier.CopierType.ARRAY;
+import static org.ecwid.dev.copier.CopierType.NO_OP;
+import static org.ecwid.dev.copier.CopierType.OBJECT;
+
+public final class DeepObjectCopier extends EventEmitter<Object> implements Copier, EventObserver<Object> {
 
     private final Map<Object, Object> memo;
     private final FieldClonerFactory fieldClonerFactory;
 
     private final Map<CopierType, Supplier<Copier>> copiersSuppliers;
     private final Map<CopierType, Copier> copierMap;
+    private final List<CopierType> handlerOrder;
 
     private DeepObjectCopier() {
         memo = new IdentityHashMap<>();
         fieldClonerFactory = FieldClonerFactory.withCopier(this);
         this.copiersSuppliers = MapBuilder.<CopierType, Supplier<Copier>>immutable()
-                .put(CopierType.ARRAY, () -> new ArrayCopier(this))
-                .put(CopierType.NO_OP, NoOpCopier::new)
-                .put(CopierType.OBJECT, () -> new ObjectCopier(this))
+                .put(ARRAY, this::arrayCopier)
+                .put(NO_OP, NoOpCopier::new)
+                .put(OBJECT, this::objectCopier)
                 .build();
         copierMap = new EnumMap<>(CopierType.class);
+        this.handlerOrder = List.of(NO_OP, ARRAY, OBJECT);
     }
 
     public static DeepObjectCopier get() {
@@ -39,7 +49,7 @@ public final class DeepObjectCopier implements Copier {
         if (obj == null) {
             return null;
         }
-        Copier copier = getCopier(obj.getClass());
+        Copier copier = getCopier(obj);
         try {
             return copier.copy(obj);
         } catch (ObjectCopyException e) {
@@ -47,14 +57,13 @@ public final class DeepObjectCopier implements Copier {
         }
     }
 
-    private Copier getCopier(Class<?> clazz) {
-        if (clazz.isSynthetic() || clazz.isEnum()) {
-            return getCopierByType(CopierType.NO_OP);
+    private Copier getCopier(Object obj) {
+        for (CopierType type : handlerOrder) {
+            if (type.canHandle(obj)) {
+                return getCopierByType(type);
+            }
         }
-        if (clazz.isArray()) {
-            return getCopierByType(CopierType.ARRAY);
-        }
-        return getCopierByType(CopierType.OBJECT);
+        throw new UnsupportedOperationException();
     }
 
     private Copier getCopierByType(CopierType copierType) {
@@ -70,7 +79,28 @@ public final class DeepObjectCopier implements Copier {
         return fieldClonerFactory;
     }
 
-    enum CopierType {
-        ARRAY, OBJECT, NO_OP
+    @Override
+    public void onEvent(Event<Object> e) {
+        if (e.type() == CopierEventType.OBJECT_CREATED) {
+            CloneData data = (CloneData) e.data();
+            saveRef(data.getObject(), data.getCopy());
+        }
+        if (e.type() == CopierEventType.CLONE_COMPLETED) {
+            notifyObservers(e);
+        }
+    }
+
+    private ObjectCopier objectCopier() {
+        ObjectCopier objectCopier = ObjectCopier.withObjectCopier(this);
+        objectCopier.registerObserver(this, CopierEventType.OBJECT_CREATED);
+        objectCopier.registerObserver(this, CopierEventType.CLONE_COMPLETED);
+        return objectCopier;
+    }
+
+    private ArrayCopier arrayCopier() {
+        ArrayCopier arrayCopier = ArrayCopier.withObjectCopier(this);
+        arrayCopier.registerObserver(this, CopierEventType.OBJECT_CREATED);
+        arrayCopier.registerObserver(this, CopierEventType.CLONE_COMPLETED);
+        return arrayCopier;
     }
 }

--- a/src/main/java/org/ecwid/dev/copier/ObjectCopier.java
+++ b/src/main/java/org/ecwid/dev/copier/ObjectCopier.java
@@ -1,16 +1,21 @@
 package org.ecwid.dev.copier;
 
+import org.ecwid.dev.event.EventEmitter;
 import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
 
-final class ObjectCopier implements Copier {
+final class ObjectCopier extends EventEmitter<Object> implements Copier {
 
     private static final Unsafe UNSAFE = getUnsafe();
     private final DeepObjectCopier copier;
 
-    ObjectCopier(DeepObjectCopier copier) {
+    private ObjectCopier(DeepObjectCopier copier) {
         this.copier = copier;
+    }
+
+    static ObjectCopier withObjectCopier(DeepObjectCopier copier) {
+        return new ObjectCopier(copier);
     }
 
 
@@ -19,11 +24,12 @@ final class ObjectCopier implements Copier {
         try {
             final Class<?> aClass = obj.getClass();
             Object copy = UNSAFE.allocateInstance(aClass);
-            copier.saveRef(obj, copy);
+            notifyObservers(CopierEvent.objectCreated(obj, copy));
             Field[] fields = aClass.getDeclaredFields();
             for (Field field : fields) {
                 copier.getFieldClonerFactory().get(field).clone(field, obj, copy);
             }
+            notifyObservers(CopierEvent.cloneCompleted(obj, copy));
             return copy;
         } catch (InstantiationException e) {
             throw new ObjectCopyException(obj, e);

--- a/src/main/java/org/ecwid/dev/copier/fieldcloner/BaseFieldCloner.java
+++ b/src/main/java/org/ecwid/dev/copier/fieldcloner/BaseFieldCloner.java
@@ -27,7 +27,9 @@ abstract class BaseFieldCloner implements FieldCloner {
         try {
             if (modifiersField.trySetAccessible()) {
                 modifiersField.setInt(field, nonFinalModifiers);
-                doClone(field, from, to);
+                if ((modifiers & Modifier.STATIC) == 0) {
+                    doClone(field, from, to);
+                } 
             }
         } finally {
             modifiersField.setInt(field, modifiers);

--- a/src/main/java/org/ecwid/dev/copier/fieldcloner/CommonFieldCloner.java
+++ b/src/main/java/org/ecwid/dev/copier/fieldcloner/CommonFieldCloner.java
@@ -4,6 +4,7 @@ import org.ecwid.dev.copier.Copier;
 import org.ecwid.dev.copier.ObjectCopyException;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 
 final class CommonFieldCloner extends BaseFieldCloner {
     private final Copier copier;
@@ -20,7 +21,12 @@ final class CommonFieldCloner extends BaseFieldCloner {
             if (field.isSynthetic() || field.isEnumConstant()) {
                 field.set(to, field.get(from));
             } else {
-                field.set(to, copier.copy(srcObj));
+                boolean isStatic = (field.getModifiers() & Modifier.STATIC) != 0;
+                if (!isStatic) {
+                    field.set(to, copier.copy(srcObj));
+                } else {
+                    field.set(to, srcObj);
+                }
             }
         } catch (IllegalAccessException e) {
             throw new ObjectCopyException(field, from, e);

--- a/src/main/java/org/ecwid/dev/event/Event.java
+++ b/src/main/java/org/ecwid/dev/event/Event.java
@@ -1,0 +1,7 @@
+package org.ecwid.dev.event;
+
+public interface Event<T> {
+    EventType type();
+
+    T data();
+}

--- a/src/main/java/org/ecwid/dev/event/EventEmitter.java
+++ b/src/main/java/org/ecwid/dev/event/EventEmitter.java
@@ -1,0 +1,26 @@
+package org.ecwid.dev.event;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class EventEmitter<T> {
+
+    private final Map<EventType, List<EventObserver<T>>> observerLists;
+
+    protected EventEmitter() {
+        observerLists = new HashMap<>();
+    }
+
+    public final void registerObserver(EventObserver<T> obs, EventType type) {
+        observerLists.computeIfAbsent(type, t -> new ArrayList<>())
+                .add(obs);
+    }
+
+    protected void notifyObservers(Event<T> e) {
+        observerLists.getOrDefault(e.type(), Collections.emptyList())
+                .forEach(obs -> obs.onEvent(e));
+    }
+}

--- a/src/main/java/org/ecwid/dev/event/EventObserver.java
+++ b/src/main/java/org/ecwid/dev/event/EventObserver.java
@@ -1,0 +1,5 @@
+package org.ecwid.dev.event;
+
+public interface EventObserver<T> {
+    void onEvent(Event<T> e);
+}

--- a/src/main/java/org/ecwid/dev/event/EventType.java
+++ b/src/main/java/org/ecwid/dev/event/EventType.java
@@ -1,0 +1,5 @@
+package org.ecwid.dev.event;
+
+public interface EventType {
+    String name();
+}

--- a/src/main/java/org/ecwid/dev/examples/Demo.java
+++ b/src/main/java/org/ecwid/dev/examples/Demo.java
@@ -15,8 +15,16 @@ public final class Demo {
     public static void main(String[] args) {
         Man man = new Man("test", 20, List.of("Lord of the Rings"));
         man.addFriend(man);
-        LOGGER.info(() -> "Source object: " + man);
-        Man copy = CopyUtils.deepCopy(man);
-        LOGGER.info(() -> "Copied object: " + copy);
+        LOGGER.info(() -> "Deep copy is being started for object : " + man);
+        Man copy = CopyUtils.deepCopy(man, Demo::logObjectClone);
+        LOGGER.info(() -> "Deep copied object: " + copy);
+    }
+
+    private static void logObjectClone(Object src, Object clone) {
+        LOGGER.info(() -> "Clone completed : " + shortObjectDescription(src) + "-> " + shortObjectDescription(clone));
+    }
+    
+    private static String shortObjectDescription(Object obj) {
+        return obj.getClass().getCanonicalName() + "@" + Integer.toHexString(System.identityHashCode(obj));
     }
 }

--- a/src/main/java/org/ecwid/dev/util/CopyUtils.java
+++ b/src/main/java/org/ecwid/dev/util/CopyUtils.java
@@ -1,12 +1,33 @@
 package org.ecwid.dev.util;
 
+import org.ecwid.dev.copier.CloneData;
+import org.ecwid.dev.copier.CopierEventType;
 import org.ecwid.dev.copier.DeepObjectCopier;
+import org.ecwid.dev.event.Event;
+
+import java.util.function.BiConsumer;
 
 public final class CopyUtils {
     private CopyUtils() {
     }
-    
+
     public static <T> T deepCopy(T obj) {
-        return (T) DeepObjectCopier.get().copy(obj);
+        return deepCopy(obj, null);
+    }
+
+    public static <T> T deepCopy(T obj, BiConsumer<Object, Object> cloneCallback) {
+        DeepObjectCopier deepObjectCopier = DeepObjectCopier.get();
+        if (cloneCallback != null) {
+            deepObjectCopier.registerObserver(
+                    e -> onCloneCompletedEvent(e, cloneCallback),
+                    CopierEventType.CLONE_COMPLETED
+            );
+        }
+        return (T) deepObjectCopier.copy(obj);
+    }
+
+    private static void onCloneCompletedEvent(Event<Object> event, BiConsumer<Object, Object> cloneCallback) {
+        CloneData data = (CloneData) event.data();
+        cloneCallback.accept(data.getObject(), data.getCopy());
     }
 }

--- a/src/test/java/org/ecwid/dev/util/CopyUtilsTest.java
+++ b/src/test/java/org/ecwid/dev/util/CopyUtilsTest.java
@@ -2,29 +2,59 @@ package org.ecwid.dev.util;
 
 import org.ecwid.dev.examples.classes.Man;
 import org.ecwid.dev.examples.classes.Primitives;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class CopyUtilsTest {
 
-    @Test
-    void deepCopy() {
+    public static Stream<Arguments> deepCopyTestCases() {
         Man man = new Man("test", 20, List.of("Lord of the Rings"));
         man.addFriend(man);
-        Man copy = CopyUtils.deepCopy(man);
-        assertNotSame(copy, man);
-        assertNotSame(copy.getName(), man.getName());
-        assertNotSame(copy.getFavoriteBooks(), man.getFavoriteBooks());
-        assertNotSame(copy.getFriends(), man.getFriends());
-        assertEquals(man, copy);
+        return Stream.of(
+                arguments(man),
+                arguments("Test"),
+                arguments(List.of(1, 2, 3)),
+                arguments(1),
+                arguments(Boolean.TRUE),
+                arguments('a'),
+                arguments(ParameterizedTest.class),
+                arguments(new Integer[] {1, 2, 3})
+        );
     }
-    
+
+    @ParameterizedTest(name = "Deep copy of {0} should be correct")
+    @MethodSource("deepCopyTestCases")
+    @DisplayName("Deep copy of an object should create different objects for all underlying fields of the object.")
+    void deepObjectCopy(Object src) {
+        // Validate that all objects cloned during deep copy have different references.
+        Object copy = CopyUtils.deepCopy(src, Assertions::assertNotSame);
+        assertEquals(src, copy);
+    }
+
+
     @Test
-    void copyPrimitives() {
+    @DisplayName("Deep copy of int array should ret")
+    void deepIntArrayCopy() {
+        int[] src = {1, 2, 3};
+        int[] copy = CopyUtils.deepCopy(src);
+        assertNotSame(src, copy);
+        assertArrayEquals(src, copy);
+    }
+
+    @Test
+    void copyPrimitiveFields() {
         Primitives primitives = Primitives.builder()
                 .setB(Byte.MAX_VALUE)
                 .setC('a')
@@ -32,7 +62,7 @@ class CopyUtilsTest {
                 .setL(1L)
                 .setS(Short.MAX_VALUE)
                 .setD(1)
-                .setIs(true)
+                .setIs(Boolean.TRUE)
                 .setF(1)
                 .build();
         Primitives copy = CopyUtils.deepCopy(primitives);


### PR DESCRIPTION
- added version of CopyUtils#deepCopy with callback
- copying of static field replaced with a reference copy
- noop clone for `Class` instances due to illegal access.
- Demo with a more detailed log of underlying copied objects
- cover with test cases